### PR TITLE
[Feature/refactor modal] 모달의 상태를 전역으로 관리하도록 변경

### DIFF
--- a/coz-shopping/src/components/Item.js
+++ b/coz-shopping/src/components/Item.js
@@ -1,12 +1,11 @@
-import { useState } from 'react';
 import styled from 'styled-components';
 import { useDispatch, useSelector } from 'react-redux';
 import { v4 as uuid } from 'uuid';
 
 import icons from '../lib/icons';
-import Modal from './Modal';
 import { toggle } from '../modules/bookmark';
 import { alertAsync } from '../modules/toast';
+import { open } from '../modules/modal';
 
 const Container = styled.div`
   height: 264px;
@@ -77,7 +76,6 @@ const Item = ({
   let subtitle = '';
   let imageUrl = image_url;
 
-  const [isModalOpen, setIsModalOpen] = useState(false);
   const { itemsId } = useSelector((state) => state.bookmark);
   const dispatch = useDispatch();
 
@@ -110,7 +108,7 @@ const Item = ({
             src={imageUrl}
             alt="img"
             onClick={() => {
-              setIsModalOpen(true);
+              dispatch(open(id, titleLeft, imageUrl));
             }}
           />
           <StarButton bookmarked={itemsId.includes(id) ? 'true' : 'false'} onClick={toggleBookmark}>
@@ -119,7 +117,7 @@ const Item = ({
         </ImageWrapper>
         <div
           onClick={() => {
-            setIsModalOpen(true);
+            dispatch(open(id, titleLeft, imageUrl));
           }}
         >
           <TitleWrapper type={type}>
@@ -132,9 +130,6 @@ const Item = ({
           <SubtitleWrapper type={type}>{subtitle}</SubtitleWrapper>
         </div>
       </Container>
-      {isModalOpen ? (
-        <Modal titleLeft={titleLeft} id={id} imageUrl={imageUrl} setIsModalOpen={setIsModalOpen} />
-      ) : undefined}
     </>
   );
 };

--- a/coz-shopping/src/components/Modal.js
+++ b/coz-shopping/src/components/Modal.js
@@ -6,6 +6,7 @@ import { v4 as uuid } from 'uuid';
 import icons from '../lib/icons';
 import { toggle } from '../modules/bookmark';
 import { alertAsync } from '../modules/toast';
+import { close } from '../modules/modal';
 
 const ModalLayer = styled.div`
   width: 100vw;
@@ -71,7 +72,7 @@ const Title = styled.span`
   line-height: 1.5px;
 `;
 
-const Modal = ({ titleLeft, id, imageUrl, setIsModalOpen }) => {
+const Modal = ({ id, titleLeft, imageUrl }) => {
   const layerRef = useRef(null);
 
   const { itemsId } = useSelector((state) => state.bookmark);
@@ -89,7 +90,7 @@ const Modal = ({ titleLeft, id, imageUrl, setIsModalOpen }) => {
 
   const closeModal = (e) => {
     if (e.target === layerRef.current) {
-      setIsModalOpen(false);
+      dispatch(close());
     }
   };
 
@@ -99,7 +100,7 @@ const Modal = ({ titleLeft, id, imageUrl, setIsModalOpen }) => {
         <ItemImage src={imageUrl} alt={titleLeft} />
         <CloseButton
           onClick={() => {
-            setIsModalOpen(false);
+            dispatch(close());
           }}
         >
           {icons.close}

--- a/coz-shopping/src/data/initialData.js
+++ b/coz-shopping/src/data/initialData.js
@@ -31,6 +31,10 @@ const initialData = {
   toast: {
     items: [],
   },
+  modal: {
+    isOpen: false,
+    content: {},
+  },
 };
 
 export default initialData;

--- a/coz-shopping/src/index.js
+++ b/coz-shopping/src/index.js
@@ -16,6 +16,7 @@ import menuReducer from './modules/menu';
 import bookmarkReducer from './modules/bookmark';
 import filterReducer from './modules/filter';
 import toastReducer from './modules/toast';
+import modalReducer from './modules/modal';
 import GlobalStyle from './components/GlobalStyle';
 
 const theme = {
@@ -39,6 +40,7 @@ const rootReducer = combineReducers({
   bookmark: bookmarkReducer,
   filter: filterReducer,
   toast: toastReducer,
+  modal: modalReducer,
 });
 
 const store = createStore(persistReducer(persistConfig, rootReducer), applyMiddleware(thunk));

--- a/coz-shopping/src/modules/modal.js
+++ b/coz-shopping/src/modules/modal.js
@@ -1,0 +1,29 @@
+import { createAction, handleActions } from 'redux-actions';
+
+import initialData from '../data/initialData';
+
+const OPEN = 'modal/OPEN';
+const CLOSE = 'modal/CLOSE';
+
+export const open = createAction(OPEN, (id, titleLeft, imageUrl) => ({
+  id,
+  titleLeft,
+  imageUrl,
+}));
+export const close = createAction(CLOSE);
+
+const modal = handleActions(
+  {
+    [OPEN]: (state, { payload: content }) => ({
+      isOpen: true,
+      content,
+    }),
+    [CLOSE]: (state) => ({
+      isOpen: false,
+      content: {},
+    }),
+  },
+  initialData.modal
+);
+
+export default modal;

--- a/coz-shopping/src/pages/ListPage.js
+++ b/coz-shopping/src/pages/ListPage.js
@@ -9,6 +9,7 @@ import Item from '../components/Item';
 import ItemSkeleton from '../components/ItemSkeleton';
 import EmptyList from '../components/EmptyList';
 import ToastContainer from '../components/ToastContainer';
+import Modal from '../components/Modal';
 
 const LIMIT = 20;
 const SKELETON_COUNT = 16;
@@ -37,6 +38,7 @@ const ListPage = ({ title }) => {
 
   const { itemsId } = useSelector((state) => state.bookmark);
   const { items } = useSelector((state) => state.toast);
+  const { modal } = useSelector((state) => state);
 
   const fetchInitialData = () => {
     setIsLoading(true);
@@ -106,6 +108,7 @@ const ListPage = ({ title }) => {
       )}
       <div ref={ref} />
       {items && <ToastContainer items={items} />}
+      {modal.isOpen && <Modal {...modal.content} />}
     </Container>
   );
 };

--- a/coz-shopping/src/pages/MainPage.js
+++ b/coz-shopping/src/pages/MainPage.js
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 
 import MainList from '../components/MainList';
 import ToastContainer from '../components/ToastContainer';
+import Modal from '../components/Modal';
 
 const Container = styled.main`
   display: flex;
@@ -19,6 +20,7 @@ const MainPage = () => {
   const [datas, setDatas] = useState([]);
 
   const { items } = useSelector((state) => state.toast);
+  const { modal } = useSelector((state) => state);
 
   useEffect(() => {
     setIsLoading(true);
@@ -35,6 +37,7 @@ const MainPage = () => {
       <MainList isLoading={isLoading} title="상품 리스트" datas={datas} />
       <MainList isLoading={isLoading} title="북마크 리스트" datas={datas} />
       {items && <ToastContainer items={items} />}
+      {modal.isOpen && <Modal {...modal.content} />}
     </Container>
   );
 };


### PR DESCRIPTION
## PR 타입

- [ ] Feature
- [x] BugFix
- [ ] Refactor
- [ ] Other

## 작업 내용

기존에는 Item 컴포넌트 내부에 Modal을 여는 로직을 두었습니다.
<img width="803" alt="스크린샷 2023-05-17 오후 4 42 09" src="https://github.com/jhsung23/fe-sprint-coz-shopping/assets/69228045/3fe0b77d-6782-49af-87e1-3ea418a0d959">

이렇게 작성했더니 북마크를 취소할 경우 클릭했던 아이템이 사라져야하는 북마크 리스트에서, 아이템이 언마운트됨과 동시에 모달도 언마운트되는 버그가 있었습니다.
![May-17-2023 16-44-30](https://github.com/jhsung23/fe-sprint-coz-shopping/assets/69228045/064cce98-b963-4052-9a83-4385f0099988)

그래서 아이템 컴포넌트 내부에 모달을 두지 않고 리덕스를 사용해 전역적으로 관리할 수 있도록 변경했습니다.

모달을 열고자하는 상황에서는 다음과 같이 `open` 액션을 디스패치하여 리덕스에서 관리하는 모달의 열림 상태(`isOpen`)와 모달에 담길 내용(`content`)를 변경해주고,
<img width="328" alt="스크린샷 2023-05-17 오후 4 48 38" src="https://github.com/jhsung23/fe-sprint-coz-shopping/assets/69228045/231fa934-6d77-4f49-adb3-132fd529dbbb">

모달을 닫고자할 때는 `close` 액션을 디스패치하여 모달의 열림 상태와 모달에 담길 내용을 초기화합니다.
<img width="265" alt="스크린샷 2023-05-17 오후 4 50 46" src="https://github.com/jhsung23/fe-sprint-coz-shopping/assets/69228045/ddfc636f-b23b-489f-a4cb-057cbd9c31ec">

모달의 열림 상태를 참조하여 `true`인 경우에 모달을 띄웁니다.
<img width="722" alt="스크린샷 2023-05-17 오후 4 47 12" src="https://github.com/jhsung23/fe-sprint-coz-shopping/assets/69228045/a00e6d1b-097c-42c2-a766-577b8cbc020a">


## 결과
![May-17-2023 16-53-25](https://github.com/jhsung23/fe-sprint-coz-shopping/assets/69228045/3934c44a-da71-42e8-a632-4d0097381634)


## 기타 참고사항
- 작성하고 나니 리팩터링이 아니라 버그픽스네요...