### PR TITLE
[Refactor] 페이지 별 초기 데이터 요청 작업을 useFetch 커스텀 훅으로 리팩터링

### DIFF
--- a/coz-shopping/src/hooks/useAxios.js
+++ b/coz-shopping/src/hooks/useAxios.js
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const useAxios = (requestCallback) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [datas, setDatas] = useState([]);
+  const [isError, setIsError] = useState(false);
+
+  const fetchData = useCallback(() => {
+    setIsLoading(true);
+    requestCallback()
+      .then((res) => {
+        setDatas(res.data);
+        setTimeout(() => {
+          setIsLoading(false);
+        }, 700);
+      })
+      .catch((err) => {
+        setIsLoading(false);
+        setIsError(true);
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return [isLoading, datas, isError];
+};
+
+export default useAxios;

--- a/coz-shopping/src/hooks/useFetch.js
+++ b/coz-shopping/src/hooks/useFetch.js
@@ -1,13 +1,15 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
 
-const useFetch = (requestCallback) => {
+const useFetch = (url) => {
   const [isLoading, setIsLoading] = useState(false);
   const [datas, setDatas] = useState([]);
   const [isError, setIsError] = useState(false);
 
-  const fetchData = useCallback(() => {
+  useEffect(() => {
     setIsLoading(true);
-    requestCallback()
+    axios
+      .get(url)
       .then((res) => {
         setDatas(res.data);
         setTimeout(() => {
@@ -18,12 +20,7 @@ const useFetch = (requestCallback) => {
         setIsLoading(false);
         setIsError(true);
       });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
+  }, [url]);
 
   return [isLoading, datas, isError];
 };

--- a/coz-shopping/src/hooks/useFetch.js
+++ b/coz-shopping/src/hooks/useFetch.js
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
-const useAxios = (requestCallback) => {
+const useFetch = (requestCallback) => {
   const [isLoading, setIsLoading] = useState(false);
   const [datas, setDatas] = useState([]);
   const [isError, setIsError] = useState(false);
@@ -28,4 +28,4 @@ const useAxios = (requestCallback) => {
   return [isLoading, datas, isError];
 };
 
-export default useAxios;
+export default useFetch;

--- a/coz-shopping/src/pages/ListPage.js
+++ b/coz-shopping/src/pages/ListPage.js
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
-import axios from 'axios';
 import { useInView } from 'react-intersection-observer';
 import { useSelector } from 'react-redux';
 
@@ -36,7 +35,7 @@ const ItemContainer = styled.div`
 const ListPage = ({ title }) => {
   const [visibleCount, setVisibleCount] = useState(LIMIT);
   const [selectedType, setSelectedType] = useState('');
-  const [isLoading, datas, isError] = useFetch(() => axios.get(SERVER_URL));
+  const [isLoading, datas, isError] = useFetch(SERVER_URL);
 
   const [ref, inView] = useInView();
 

--- a/coz-shopping/src/pages/ListPage.js
+++ b/coz-shopping/src/pages/ListPage.js
@@ -12,7 +12,7 @@ import ToastContainer from '../components/ToastContainer';
 import Modal from '../components/Modal';
 import FetchError from '../components/FetchError';
 import { MAIN_LIST, MENU } from '../lib/constants';
-import useAxios from '../hooks/useAxios';
+import useFetch from '../hooks/useFetch';
 
 const LIMIT = 20;
 const SKELETON_COUNT = 16;
@@ -36,7 +36,7 @@ const ItemContainer = styled.div`
 const ListPage = ({ title }) => {
   const [visibleCount, setVisibleCount] = useState(LIMIT);
   const [selectedType, setSelectedType] = useState('');
-  const [isLoading, datas, isError] = useAxios(() => axios.get(SERVER_URL));
+  const [isLoading, datas, isError] = useFetch(() => axios.get(SERVER_URL));
 
   const [ref, inView] = useInView();
 

--- a/coz-shopping/src/pages/ListPage.js
+++ b/coz-shopping/src/pages/ListPage.js
@@ -12,6 +12,7 @@ import ToastContainer from '../components/ToastContainer';
 import Modal from '../components/Modal';
 import FetchError from '../components/FetchError';
 import { MAIN_LIST, MENU } from '../lib/constants';
+import useAxios from '../hooks/useAxios';
 
 const LIMIT = 20;
 const SKELETON_COUNT = 16;
@@ -33,33 +34,15 @@ const ItemContainer = styled.div`
 `;
 
 const ListPage = ({ title }) => {
-  const [datas, setDatas] = useState([]);
   const [visibleCount, setVisibleCount] = useState(LIMIT);
-  const [isLoading, setIsLoading] = useState(false);
   const [selectedType, setSelectedType] = useState('');
-  const [error, setError] = useState(false);
+  const [isLoading, datas, isError] = useAxios(() => axios.get(SERVER_URL));
 
   const [ref, inView] = useInView();
 
   const { bookmark } = useSelector((state) => state);
   const { toast } = useSelector((state) => state);
   const { modal } = useSelector((state) => state);
-
-  const fetchInitialData = () => {
-    setIsLoading(true);
-    axios
-      .get(SERVER_URL)
-      .then((res) => {
-        setDatas(res.data);
-        setTimeout(() => {
-          setIsLoading(false);
-        }, 700);
-      })
-      .catch((err) => {
-        setError(true);
-        setIsLoading(false);
-      });
-  };
 
   const loadMoreData = useCallback(() => {
     setVisibleCount((prevState) => prevState + LIMIT);
@@ -97,10 +80,6 @@ const ListPage = ({ title }) => {
   };
 
   useEffect(() => {
-    fetchInitialData();
-  }, []);
-
-  useEffect(() => {
     if (inView) {
       loadMoreData();
     }
@@ -108,7 +87,7 @@ const ListPage = ({ title }) => {
 
   return (
     <Container>
-      {error ? (
+      {isError ? (
         <FetchError />
       ) : (
         <>

--- a/coz-shopping/src/pages/MainPage.js
+++ b/coz-shopping/src/pages/MainPage.js
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import axios from 'axios';
 import { useSelector } from 'react-redux';
 
 import MainList from '../components/MainList';
@@ -20,7 +19,7 @@ const Container = styled.main`
 `;
 
 const MainPage = () => {
-  const [isLoading, datas, isError] = useFetch(() => axios.get(SERVER_URL));
+  const [isLoading, datas, isError] = useFetch(SERVER_URL);
 
   const { toast } = useSelector((state) => state);
   const { modal } = useSelector((state) => state);

--- a/coz-shopping/src/pages/MainPage.js
+++ b/coz-shopping/src/pages/MainPage.js
@@ -7,7 +7,7 @@ import ToastContainer from '../components/ToastContainer';
 import Modal from '../components/Modal';
 import FetchError from '../components/FetchError';
 import { MAIN_LIST } from '../lib/constants';
-import useAxios from '../hooks/useAxios';
+import useFetch from '../hooks/useFetch';
 
 const SERVER_URL = 'http://cozshopping.codestates-seb.link/api/v1/products';
 
@@ -20,7 +20,7 @@ const Container = styled.main`
 `;
 
 const MainPage = () => {
-  const [isLoading, datas, isError] = useAxios(() => axios.get(SERVER_URL));
+  const [isLoading, datas, isError] = useFetch(() => axios.get(SERVER_URL));
 
   const { toast } = useSelector((state) => state);
   const { modal } = useSelector((state) => state);

--- a/coz-shopping/src/pages/MainPage.js
+++ b/coz-shopping/src/pages/MainPage.js
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import axios from 'axios';
 import { useSelector } from 'react-redux';
@@ -8,6 +7,7 @@ import ToastContainer from '../components/ToastContainer';
 import Modal from '../components/Modal';
 import FetchError from '../components/FetchError';
 import { MAIN_LIST } from '../lib/constants';
+import useAxios from '../hooks/useAxios';
 
 const SERVER_URL = 'http://cozshopping.codestates-seb.link/api/v1/products';
 
@@ -20,32 +20,14 @@ const Container = styled.main`
 `;
 
 const MainPage = () => {
-  const [isLoading, setIsLoading] = useState(false);
-  const [datas, setDatas] = useState([]);
-  const [error, setError] = useState(false);
+  const [isLoading, datas, isError] = useAxios(() => axios.get(SERVER_URL));
 
   const { toast } = useSelector((state) => state);
   const { modal } = useSelector((state) => state);
 
-  useEffect(() => {
-    setIsLoading(true);
-    axios
-      .get(SERVER_URL)
-      .then((res) => {
-        setDatas(res.data);
-        setTimeout(() => {
-          setIsLoading(false);
-        }, 700);
-      })
-      .catch((err) => {
-        setIsLoading(false);
-        setError(true);
-      });
-  }, []);
-
   return (
     <Container>
-      {error ? (
+      {isError ? (
         <FetchError />
       ) : (
         <>


### PR DESCRIPTION
## PR 타입

- [ ] Feature
- [ ] BugFix
- [x] Refactor
- [ ] Other

## 작업 내용

각 페이지가 마운트될 때, 초기 데이터를 받아오기 위해 useEffect 내부에서 실행했던 `axios.get` 요청을 커스텀 훅으로 분리하는 작업을 했습니다.

메인 페이지에서는 다음과 같이 3가지 상태를 가지고 있으며, get 요청을 수행한 다음 초기 `datas`가 fetch됩니다. (ListPage에서도 동일함)
<img width="721" alt="스크린샷 2023-05-22 오후 3 05 16" src="https://github.com/jhsung23/fe-sprint-coz-shopping/assets/69228045/e4452427-aabe-448f-87f8-cd9d2f8b077b">

위 내용을 커스텀 훅으로 다음과 같이 분리시켰으며, props로 요청을 보낼 엔드포인트를 받아 get 요청을 보냅니다.
<img width="601" alt="스크린샷 2023-05-27 오후 10 39 25" src="https://github.com/jhsung23/fe-sprint-coz-shopping/assets/69228045/68a3ea24-2126-45d2-86bb-28283b828fb3">


각 페이지에서 작성한 훅을 사용해 다음처럼 fetch 작업을 할 수 있습니다.
<img width="570" alt="스크린샷 2023-05-27 오후 10 40 44" src="https://github.com/jhsung23/fe-sprint-coz-shopping/assets/69228045/cbefb5c5-3376-4487-bf49-049596db9372">


## 결과

## 기타 참고사항
